### PR TITLE
Add setup and teardown to suites (no forking)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ EXTENSION:=
 TEST_ENV:=
 CFLAGS:=
 AGGRESSIVE_WARNINGS=n
+OUT_DIR:= build/
 
 ifeq ($(CC),pgcc)
         CFLAGS+=-c$(CSTD)
@@ -43,13 +44,23 @@ ifneq ($(CC),pgcc)
         endif
 endif
 
-example$(EXTENSION): munit.h munit.c example.c
-	$(CC) $(CFLAGS) -o $@ munit.c example.c
+${OUT_DIR}:
+	mkdir -p ${OUT_DIR}
 
-test:
-	$(TEST_ENV) ./example$(EXTENSION)
+example$(EXTENSION): munit.h munit.c tests/example.c
+	$(CC) $(CFLAGS) -I./ -o ${OUT_DIR}$@ munit.c tests/example.c
+
+
+test_nested_suites$(EXTENSION): munit.h munit.c tests/test_nested_suites.c
+	$(CC) $(CFLAGS) -I./ -DMUNIT_FAIL_NO_TEST_RUN -o ${OUT_DIR}$@ munit.c tests/test_nested_suites.c
+
+test: ${OUT_DIR} example$(EXTENSION) test_nested_suites$(EXTENSION)
+	$(TEST_ENV) ./${OUT_DIR}example$(EXTENSION)
+	$(TEST_ENV) ./${OUT_DIR}test_nested_suites$(EXTENSION)
 
 clean:
-	rm -f example$(EXTENSION)
+	rm -f ${OUT_DIR}example$(EXTENSION)
+	rm -f ${OUT_DIR}test_*$(EXTENSION)
+	rm -rf ${OUT_DIR}
 
-all: example$(EXTENSION)
+all: ${OUT_DIR} example$(EXTENSION) test_nested_suites$(EXTENSION)

--- a/munit.h
+++ b/munit.h
@@ -436,6 +436,8 @@ typedef enum {
 typedef MunitResult (* MunitTestFunc)(const MunitParameter params[], void* user_data_or_fixture);
 typedef void*       (* MunitTestSetup)(const MunitParameter params[], void* user_data);
 typedef void        (* MunitTestTearDown)(void* fixture);
+typedef void*       (* MunitSuiteSetup)(void* user_data);
+typedef void        (* MunitSuiteTearDown)(void* fixture);
 
 typedef struct {
   char*               name;
@@ -453,11 +455,13 @@ typedef enum {
 typedef struct MunitSuite_ MunitSuite;
 
 struct MunitSuite_ {
-  char*             prefix;
-  MunitTest*        tests;
-  MunitSuite*       suites;
-  unsigned int      iterations;
-  MunitSuiteOptions options;
+  char*               prefix;
+  MunitTest*          tests;
+  MunitSuiteSetup     setup;
+  MunitSuiteTearDown  tear_down;
+  MunitSuite*         suites;
+  unsigned int        iterations;
+  MunitSuiteOptions   options;
 };
 
 int munit_suite_main(const MunitSuite* suite, void* user_data, int argc, char* const argv[MUNIT_ARRAY_PARAM(argc + 1)]);

--- a/tests/example.c
+++ b/tests/example.c
@@ -320,6 +320,14 @@ static const MunitSuite test_suite = {
   (char*) "",
   /* The first parameter is the array of test suites. */
   test_suite_tests,
+  /* Following the array of tests, an optional setup function that is
+   * executed only once before any test in the suite.
+   */
+  NULL,
+  /* An optional teardown function that is executed only once before
+   * any test in the suite.
+   */
+  NULL,
   /* In addition to containing test cases, suites can contain other
    * test suites.  This isn't necessary in this example, but it can be
    * a great help to projects with lots of tests by making it easier

--- a/tests/test_nested_suites.c
+++ b/tests/test_nested_suites.c
@@ -1,0 +1,157 @@
+#include "munit.h"
+
+typedef struct {
+    int suite_setup_calls;
+    int suite_teardown_calls;
+    int test_setup_calls;
+    int test_teardown_calls;
+    int test_calls_a;
+    int test_calls_b;
+} test_call_t;
+
+static void reset_test(test_call_t *tests) {
+    tests->suite_setup_calls = 0;
+    tests->suite_teardown_calls = 0;
+    tests->test_setup_calls = 0;
+    tests->test_teardown_calls = 0;
+    tests->test_calls_a = 0;
+    tests->test_calls_b = 0;
+}
+
+static void assert_calls(test_call_t *tests, int suite_setup_calls, int suite_teardown_calls, int test_setup_calls,
+                         int test_teardown_calls, int test_calls_a, int test_calls_b) {
+    munit_assert_int(suite_setup_calls, ==, tests->suite_setup_calls);
+    munit_assert_int(suite_teardown_calls, ==, tests->suite_teardown_calls);
+    munit_assert_int(test_setup_calls, ==, tests->test_setup_calls);
+    munit_assert_int(test_teardown_calls, ==, tests->test_teardown_calls);
+    munit_assert_int(test_calls_a, ==, tests->test_calls_a);
+    munit_assert_int(test_calls_b, ==, tests->test_calls_b);
+}
+
+static void* suite_setup(void* data) {
+    ((test_call_t*) data)->suite_setup_calls++;
+    return data;
+}
+
+static void suite_teardown(void* data) {
+    ((test_call_t*) data)->suite_teardown_calls++;
+}
+
+
+static void* test_setup(const MunitParameter params[], void* data) {
+    ((test_call_t*) data)->test_setup_calls++;
+    return data;
+}
+
+static void test_teardown(void* data) {
+    ((test_call_t*) data)->test_teardown_calls++;
+}
+
+static MunitResult test_func_1(const MunitParameter params[], void* data) {
+    ((test_call_t*) data)->test_calls_a++;
+    return MUNIT_OK;
+}
+
+
+static MunitResult test_func_2(const MunitParameter params[], void* data) {
+    ((test_call_t*) data)->test_calls_b++;
+    return MUNIT_OK;
+}
+
+static MunitTest test_a[] = {
+        {"test_a1", test_func_1, test_setup, test_teardown, MUNIT_TEST_OPTION_NONE, NULL},
+        {"test_a2", test_func_2, test_setup, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+        {NULL, NULL, NULL, NULL, 0, MUNIT_TEST_OPTION_NONE}
+};
+
+
+static MunitTest test_b[] = {
+        {"test_b1", test_func_1, NULL, test_teardown, MUNIT_TEST_OPTION_NONE, NULL},
+        {"test_b2", test_func_2, NULL, NULL, MUNIT_TEST_OPTION_NONE, NULL},
+        {NULL, NULL, NULL, NULL, 0, MUNIT_TEST_OPTION_NONE}
+};
+
+static MunitSuite main_suite[] = {
+        {"nested_a/", test_a, suite_setup, suite_teardown, NULL, 7, MUNIT_SUITE_OPTION_NONE},
+        {"nested_b/", test_b, NULL, NULL, NULL, 5, MUNIT_SUITE_OPTION_NONE},
+        {NULL, NULL, NULL, NULL, NULL, 0, MUNIT_SUITE_OPTION_NONE}
+};
+
+static const MunitSuite root_suite = {
+        "",
+        /* No tests running for root suite needed */
+        NULL,
+        NULL,
+        NULL,
+        main_suite,
+        0,
+        MUNIT_SUITE_OPTION_NONE
+};
+
+
+int main(int argc, char *argv[MUNIT_ARRAY_PARAM(argc + 1)]) {
+    //test all suites run
+    char* args_all_tests[] = {
+            "Program",
+            "--no-fork",
+            NULL
+    };
+    char* args_all_suite_a[] = {
+            "Program",
+            "--no-fork",
+            "nested_a",
+            NULL
+    };
+    char* args_all_suite_b[] = {
+            "Program",
+            "--no-fork",
+            "nested_b",
+            NULL
+    };
+    char* args_test_a1[] = {
+            "Program",
+            "--no-fork",
+            "nested_a/test_a1",
+            NULL
+    };
+    char* args_test_b2[] = {
+            "Program",
+            "--no-fork",
+            "nested_b/test_b2",
+            NULL
+    };
+    char* args_no_test_case[] = {
+            "Program",
+            "--no-fork",
+            "something",
+            NULL
+    };
+
+    //Test calling cases by name and suite name
+    test_call_t calls;
+    reset_test(&calls);
+    munit_assert(munit_suite_main(&root_suite, (void *) &calls, 2, args_all_tests) == EXIT_SUCCESS);
+    assert_calls(&calls, 1, 1, 14, 12, 12, 12);
+
+    reset_test(&calls);
+    munit_assert(munit_suite_main(&root_suite, (void *) &calls, 3, args_all_suite_a) == EXIT_SUCCESS);
+    assert_calls(&calls, 1, 1, 14, 7, 7, 7);
+
+    reset_test(&calls);
+    munit_assert(munit_suite_main(&root_suite, (void *) &calls, 3, args_all_suite_b) == EXIT_SUCCESS);
+    assert_calls(&calls, 0, 0, 0, 5, 5, 5);
+
+    reset_test(&calls);
+    munit_assert(munit_suite_main(&root_suite, (void *) &calls, 3, args_test_a1) == EXIT_SUCCESS);
+    assert_calls(&calls, 1, 1, 7, 7, 7, 0);
+
+    reset_test(&calls);
+    munit_assert(munit_suite_main(&root_suite, (void *) &calls, 3, args_test_b2) == EXIT_SUCCESS);
+    assert_calls(&calls, 0, 0, 0, 0, 0, 5);
+
+    reset_test(&calls);
+    munit_assert(munit_suite_main(&root_suite, (void *) &calls, 3, args_no_test_case) == EXIT_FAILURE);
+    assert_calls(&calls, 0, 0, 0, 0, 0, 0);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
For some use cases, it is interesting to setup once per suite, for all tests and suites-of-suites declared inside it.
This PR adds little modification to include this feature.

Observe that there is a necessary step for migration, since the MunitSuite has two new attributes (`setup` and `teardown`)
```
struct MunitSuite_ {
  char*               prefix;
  MunitTest*          tests;
  MunitSuiteSetup     setup;
  MunitSuiteTearDown  tear_down;
  MunitSuite*         suites;
  unsigned int        iterations;
  MunitSuiteOptions   options;
};
```
The rationale of the change is as follows:
* When iterating through a suite, if at least one test is executed, the setup is also executed.
* If the setup was executed, the teardown will be called after all called tests in the suite are finished.
* The original input data pointer is preserved across suites, that is, modifying the data pointer in the suite setup will not change original data passed down to other suites.
* The teardown is executed before calling nested suites.



Regarding forking and setup/teardown failure
---

The main drawback is that *forking* (if enabled) is not used for the suite setup and teardown. 
Since forking does not share memory between child and parent, it would add too much complexity to the PR.

On the other hand, it would be nice to have forking support for the suite setup/teardown, to be able to catch seg fault cases and continue testing when things go wrong.

Since the suite setup and teardown are treated in their own static function, we can add the forking code to these functions without changing the rest of the code. However, a few blockers were met:
* Failing should be treated and fail the entire suite
* Sharing memory with child using `mmap` and flag `MAP_ANONYMOUS ` is not supported in std `c99` (requires GNU flag)